### PR TITLE
[FEAT] Notification APIs

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,7 @@ import { LikesModule } from './modules/likes/likes.module';
 import { UsersModule } from './modules/users/users.module';
 import { ChallengeModule } from './modules/challenges/challenge.module';
 import { ChatModule } from './modules/chat/chat.module';
+import { NotificationsModule } from './modules/notifications/notifications.module';
 @Module({
   imports: [
     ConfigModule.forRoot({
@@ -38,6 +39,7 @@ import { ChatModule } from './modules/chat/chat.module';
     UsersModule,
     ChallengeModule,
     ChatModule,
+    NotificationsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/modules/notifications/decorators/notifications.swagger.ts
+++ b/src/modules/notifications/decorators/notifications.swagger.ts
@@ -1,0 +1,299 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiBody,
+  ApiBearerAuth,
+  ApiQuery,
+  ApiParam,
+} from '@nestjs/swagger';
+import {
+  CommonErrorResponses,
+  CommonAuthResponses,
+  createErrorResponse,
+} from '@/decorators/swagger.decorator';
+
+export function ApiCreateNotification() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '알림 생성',
+      description: '새로운 알림을 생성합니다. (시스템용)',
+    }),
+    ApiBearerAuth(),
+    ApiBody({
+      schema: {
+        type: 'object',
+        required: ['recipientUuid', 'type', 'title', 'content'],
+        properties: {
+          recipientUuid: {
+            type: 'string',
+            description: '수신자 UUID',
+            example: '01HZQK5J8X2M3N4P5Q6R7S8T9V',
+          },
+          senderUuid: {
+            type: 'string',
+            description: '발신자 UUID (선택적)',
+            example: '01HZQK5J8X2M3N4P5Q6R7S8T9V',
+          },
+          type: {
+            type: 'string',
+            enum: [
+              'friend_request',
+              'friend_accepted',
+              'challenge_invite',
+              'challenge_start',
+              'challenge_end',
+              'new_message',
+              'post_like',
+              'post_comment',
+              'mention',
+            ],
+            description: '알림 타입',
+            example: 'friend_request',
+          },
+          title: {
+            type: 'string',
+            description: '알림 제목',
+            example: '친구 요청이 도착했습니다',
+          },
+          content: {
+            type: 'string',
+            description: '알림 내용',
+            example: '김철수님이 친구 요청을 보냈습니다.',
+          },
+          data: {
+            type: 'object',
+            description: '추가 데이터 (JSON)',
+            example: { friendRequestId: 123 },
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 201,
+      description: '알림이 성공적으로 생성됨',
+      schema: {
+        type: 'object',
+        properties: {
+          id: { type: 'number', example: 1 },
+          recipientUuid: {
+            type: 'string',
+            example: '01HZQK5J8X2M3N4P5Q6R7S8T9V',
+          },
+          senderUuid: { type: 'string', example: '01HZQK5J8X2M3N4P5Q6R7S8T9V' },
+          type: { type: 'string', example: 'friend_request' },
+          title: { type: 'string', example: '친구 요청이 도착했습니다' },
+          content: {
+            type: 'string',
+            example: '김철수님이 친구 요청을 보냈습니다.',
+          },
+          data: { type: 'object', example: { friendRequestId: 123 } },
+          isRead: { type: 'boolean', example: false },
+          isSent: { type: 'boolean', example: false },
+          createdAt: {
+            type: 'string',
+            format: 'date-time',
+            example: '2025-06-22T12:00:00Z',
+          },
+          updatedAt: {
+            type: 'string',
+            format: 'date-time',
+            example: '2025-06-22T12:00:00Z',
+          },
+        },
+      },
+    }),
+    ApiResponse(CommonErrorResponses.NotFound),
+    ApiResponse(CommonAuthResponses.Unauthorized),
+    ApiResponse(CommonErrorResponses.ValidationFailed),
+    ApiResponse(CommonErrorResponses.InternalServerError),
+  );
+}
+
+export function ApiGetNotifications() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '알림 목록 조회',
+      description: '사용자의 알림 목록을 페이지네이션으로 조회합니다.',
+    }),
+    ApiQuery({
+      name: 'page',
+      required: false,
+      description: '페이지 번호 (기본값: 1)',
+      example: 1,
+    }),
+    ApiQuery({
+      name: 'limit',
+      required: false,
+      description: '페이지당 항목 수 (기본값: 20)',
+      example: 20,
+    }),
+    ApiQuery({
+      name: 'unreadOnly',
+      required: false,
+      description: '미읽음 알림만 조회',
+      example: false,
+    }),
+    ApiQuery({
+      name: 'type',
+      required: false,
+      description: '알림 타입 필터',
+      enum: [
+        'friend_request',
+        'friend_accepted',
+        'challenge_invite',
+        'challenge_start',
+        'challenge_end',
+        'new_message',
+        'post_like',
+        'post_comment',
+        'mention',
+      ],
+    }),
+    ApiResponse({
+      status: 200,
+      description: '알림 목록 조회 성공',
+      schema: {
+        type: 'object',
+        properties: {
+          notifications: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'number', example: 1 },
+                recipientUuid: {
+                  type: 'string',
+                  example: '01HZQK5J8X2M3N4P5Q6R7S8T9V',
+                },
+                senderUuid: {
+                  type: 'string',
+                  example: '01HZQK5J8X2M3N4P5Q6R7S8T9V',
+                },
+                type: { type: 'string', example: 'friend_request' },
+                title: { type: 'string', example: '친구 요청이 도착했습니다' },
+                content: {
+                  type: 'string',
+                  example: '김철수님이 친구 요청을 보냈습니다.',
+                },
+                data: { type: 'object', example: { friendRequestId: 123 } },
+                isRead: { type: 'boolean', example: false },
+                isSent: { type: 'boolean', example: true },
+                createdAt: {
+                  type: 'string',
+                  format: 'date-time',
+                  example: '2025-06-22T12:00:00Z',
+                },
+                updatedAt: {
+                  type: 'string',
+                  format: 'date-time',
+                  example: '2025-06-22T12:00:00Z',
+                },
+              },
+            },
+          },
+          pagination: {
+            type: 'object',
+            properties: {
+              currentPage: { type: 'number', example: 1 },
+              totalPages: { type: 'number', example: 5 },
+              totalItems: { type: 'number', example: 100 },
+              itemsPerPage: { type: 'number', example: 20 },
+            },
+          },
+          unreadCount: { type: 'number', example: 5 },
+        },
+      },
+    }),
+  );
+}
+
+export function ApiGetUnreadCount() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '미읽음 알림 개수 조회',
+      description: '사용자의 미읽음 알림 개수를 조회합니다.',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '미읽음 알림 개수 조회 성공',
+      schema: {
+        type: 'object',
+        properties: {
+          unreadCount: { type: 'number', example: 5 },
+        },
+      },
+    }),
+  );
+}
+
+export function ApiMarkAsRead() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '알림 읽음 처리',
+      description:
+        '지정된 알림들을 읽음 상태로 변경합니다. notificationIds가 없으면 모든 미읽음 알림을 읽음 처리합니다.',
+    }),
+    ApiBody({
+      schema: {
+        type: 'object',
+        properties: {
+          notificationIds: {
+            type: 'array',
+            items: { type: 'number' },
+            description: '읽음 처리할 알림 ID 배열 (선택적)',
+            example: [1, 2, 3],
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 200,
+      description: '알림 읽음 처리 성공',
+      schema: {
+        type: 'object',
+        properties: {
+          success: { type: 'boolean', example: true },
+          message: {
+            type: 'string',
+            example: '3개의 알림이 읽음 처리되었습니다.',
+          },
+        },
+      },
+    }),
+  );
+}
+
+export function ApiDeleteNotification() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '알림 삭제',
+      description: '지정된 알림을 삭제합니다.',
+    }),
+    ApiParam({
+      name: 'id',
+      description: '삭제할 알림 ID',
+      example: 1,
+    }),
+    ApiResponse({
+      status: 200,
+      description: '알림 삭제 성공',
+      schema: {
+        type: 'object',
+        properties: {
+          success: { type: 'boolean', example: true },
+          message: { type: 'string', example: '알림이 삭제되었습니다.' },
+        },
+      },
+    }),
+    ApiResponse(
+      createErrorResponse(
+        'NOTIFICATION_001',
+        '해당 알림을 찾을 수 없습니다.',
+        404,
+      ),
+    ),
+    ApiResponse(CommonAuthResponses.Unauthorized),
+    ApiResponse(CommonErrorResponses.InternalServerError),
+  );
+}

--- a/src/modules/notifications/dto/create-notification.dto.ts
+++ b/src/modules/notifications/dto/create-notification.dto.ts
@@ -1,0 +1,24 @@
+import { IsString, IsEnum, IsOptional, IsObject } from 'class-validator';
+import { NotificationType } from '@/types/notification.enum';
+
+export class CreateNotificationDto {
+  @IsString()
+  recipientUuid: string;
+
+  @IsString()
+  @IsOptional()
+  senderUuid?: string;
+
+  @IsEnum(NotificationType)
+  type: NotificationType;
+
+  @IsString()
+  title: string;
+
+  @IsString()
+  content: string;
+
+  @IsObject()
+  @IsOptional()
+  data?: any;
+}

--- a/src/modules/notifications/dto/get-notifications.dto.ts
+++ b/src/modules/notifications/dto/get-notifications.dto.ts
@@ -1,0 +1,26 @@
+import { IsOptional, IsBoolean, IsEnum, IsNumber, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { NotificationType } from '@/types/notification.enum';
+
+export class GetNotificationsDto {
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Type(() => Number)
+  page?: number = 1;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Type(() => Number)
+  limit?: number = 20;
+
+  @IsOptional()
+  @IsBoolean()
+  @Type(() => Boolean)
+  unreadOnly?: boolean;
+
+  @IsOptional()
+  @IsEnum(NotificationType)
+  type?: NotificationType;
+}

--- a/src/modules/notifications/dto/mark-as-read.dto.ts
+++ b/src/modules/notifications/dto/mark-as-read.dto.ts
@@ -1,0 +1,8 @@
+import { IsArray, IsNumber, IsOptional } from 'class-validator';
+
+export class MarkAsReadDto {
+  @IsArray()
+  @IsNumber({}, { each: true })
+  @IsOptional()
+  notificationIds?: number[];
+}

--- a/src/modules/notifications/dto/notification-response.dto.ts
+++ b/src/modules/notifications/dto/notification-response.dto.ts
@@ -1,0 +1,26 @@
+import { NotificationType } from '@/types/notification.enum';
+
+export class NotificationResponseDto {
+  id: number;
+  recipientUuid: string;
+  senderUuid?: string;
+  type: NotificationType;
+  title: string;
+  content: string;
+  data?: any;
+  isRead: boolean;
+  isSent: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export class NotificationListResponseDto {
+  notifications: NotificationResponseDto[];
+  pagination: {
+    currentPage: number;
+    totalPages: number;
+    totalItems: number;
+    itemsPerPage: number;
+  };
+  unreadCount: number;
+}

--- a/src/modules/notifications/notifications.controller.ts
+++ b/src/modules/notifications/notifications.controller.ts
@@ -1,0 +1,100 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Patch,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  ParseIntPipe,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { NotificationsService } from './notifications.service';
+import { CreateNotificationDto } from './dto/create-notification.dto';
+import { GetNotificationsDto } from './dto/get-notifications.dto';
+import { MarkAsReadDto } from './dto/mark-as-read.dto';
+import { UserUuid } from '@/decorators/user-uuid.decorator';
+import { JwtAuthGuard } from '@/auth/guards/jwt-auth.guard';
+import {
+  ApiCreateNotification,
+  ApiGetNotifications,
+  ApiMarkAsRead,
+  ApiDeleteNotification,
+  ApiGetUnreadCount,
+} from './decorators/notifications.swagger';
+
+@ApiTags('notifications')
+@ApiBearerAuth('JWT-auth')
+@Controller('notifications')
+@UseGuards(JwtAuthGuard)
+export class NotificationsController {
+  constructor(private readonly notificationsService: NotificationsService) {}
+
+  /**
+   * 새 알림 생성 (시스템용 - 관리자 권한 필요)
+   */
+  @Post()
+  @ApiCreateNotification()
+  createNotification(@Body() createNotificationDto: CreateNotificationDto) {
+    return this.notificationsService.createNotification(createNotificationDto);
+  }
+
+  /**
+   * 사용자의 알림 목록 조회
+   */
+  @Get()
+  @ApiGetNotifications()
+  getNotifications(
+    @Query() getNotificationsDto: GetNotificationsDto,
+    @UserUuid() userUuid: string,
+  ) {
+    return this.notificationsService.getNotifications(
+      userUuid,
+      getNotificationsDto,
+    );
+  }
+
+  /**
+   * 미읽음 알림 개수 조회
+   */
+  @Get('unread-count')
+  @ApiGetUnreadCount()
+  getUnreadCount(@UserUuid() userUuid: string) {
+    return this.notificationsService.getUnreadCount(userUuid);
+  }
+
+  /**
+   * 알림 읽음 처리
+   */
+  @Patch('mark-as-read')
+  @ApiMarkAsRead()
+  markAsRead(
+    @Body() markAsReadDto: MarkAsReadDto,
+    @UserUuid() userUuid: string,
+  ) {
+    return this.notificationsService.markAsRead(userUuid, markAsReadDto);
+  }
+
+  /**
+   * 모든 알림 읽음 처리
+   */
+  @Patch('mark-all-as-read')
+  @ApiMarkAsRead()
+  markAllAsRead(@UserUuid() userUuid: string) {
+    return this.notificationsService.markAsRead(userUuid);
+  }
+
+  /**
+   * 알림 삭제
+   */
+  @Delete(':id')
+  @ApiDeleteNotification()
+  deleteNotification(
+    @Param('id', ParseIntPipe) id: number,
+    @UserUuid() userUuid: string,
+  ) {
+    return this.notificationsService.deleteNotification(userUuid, id);
+  }
+}

--- a/src/modules/notifications/notifications.module.ts
+++ b/src/modules/notifications/notifications.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Notification } from '@/entities/notification.entity';
+import { User } from '@/entities/user.entity';
+import { NotificationsController } from './notifications.controller';
+import { NotificationsService } from './notifications.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Notification, User])],
+  controllers: [NotificationsController],
+  providers: [NotificationsService],
+  exports: [NotificationsService],
+})
+export class NotificationsModule {}

--- a/src/modules/notifications/notifications.service.ts
+++ b/src/modules/notifications/notifications.service.ts
@@ -1,0 +1,329 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, In } from 'typeorm';
+import { Notification } from '@/entities/notification.entity';
+import { User } from '@/entities/user.entity';
+import { CreateNotificationDto } from './dto/create-notification.dto';
+import { GetNotificationsDto } from './dto/get-notifications.dto';
+import { MarkAsReadDto } from './dto/mark-as-read.dto';
+import {
+  NotificationListResponseDto,
+  NotificationResponseDto,
+} from './dto/notification-response.dto';
+import { NotificationType } from '@/types/notification.enum';
+import { BusinessException } from '@/utils/custom-exception';
+
+@Injectable()
+export class NotificationsService {
+  constructor(
+    @InjectRepository(Notification)
+    private notificationRepository: Repository<Notification>,
+    @InjectRepository(User)
+    private userRepository: Repository<User>,
+  ) {}
+
+  /**
+   * 새 알림 생성
+   */
+  async createNotification(
+    createNotificationDto: CreateNotificationDto,
+  ): Promise<NotificationResponseDto> {
+    // 수신자 존재 확인
+    const recipient = await this.userRepository.findOne({
+      where: { userUuid: createNotificationDto.recipientUuid },
+    });
+
+    if (!recipient) {
+      BusinessException.userNotFound(createNotificationDto.recipientUuid);
+    }
+
+    // 발신자 존재 확인 (선택적)
+    if (createNotificationDto.senderUuid) {
+      const sender = await this.userRepository.findOne({
+        where: { userUuid: createNotificationDto.senderUuid },
+      });
+
+      if (!sender) {
+        BusinessException.userNotFound(createNotificationDto.senderUuid);
+      }
+    }
+
+    const notification = this.notificationRepository.create(
+      createNotificationDto,
+    );
+    const savedNotification =
+      await this.notificationRepository.save(notification);
+
+    return this.mapToResponseDto(savedNotification);
+  }
+
+  /**
+   * 사용자의 알림 목록 조회 (페이지네이션)
+   */
+  async getNotifications(
+    userUuid: string,
+    getNotificationsDto: GetNotificationsDto,
+  ): Promise<NotificationListResponseDto> {
+    const { page = 1, limit = 20, unreadOnly, type } = getNotificationsDto;
+    const skip = (page - 1) * limit;
+
+    const queryBuilder = this.notificationRepository
+      .createQueryBuilder('notification')
+      .where('notification.recipientUuid = :userUuid', { userUuid })
+      .orderBy('notification.createdAt', 'DESC');
+
+    // 미읽음 알림만 필터링
+    if (unreadOnly) {
+      queryBuilder.andWhere('notification.isRead = :isRead', { isRead: false });
+    }
+
+    // 알림 타입 필터링
+    if (type) {
+      queryBuilder.andWhere('notification.type = :type', { type });
+    }
+
+    // 전체 개수 조회
+    const totalItems = await queryBuilder.getCount();
+
+    // 페이지네이션 적용
+    const notifications = await queryBuilder.skip(skip).take(limit).getMany();
+
+    // 미읽음 알림 개수 조회
+    const unreadCount = await this.notificationRepository.count({
+      where: {
+        recipientUuid: userUuid,
+        isRead: false,
+      },
+    });
+
+    const totalPages = Math.ceil(totalItems / limit);
+
+    return {
+      notifications: notifications.map((notification) =>
+        this.mapToResponseDto(notification),
+      ),
+      pagination: {
+        currentPage: page,
+        totalPages,
+        totalItems,
+        itemsPerPage: limit,
+      },
+      unreadCount,
+    };
+  }
+
+  /**
+   * 알림 읽음 처리
+   */
+  async markAsRead(
+    userUuid: string,
+    markAsReadDto?: MarkAsReadDto,
+  ): Promise<{ success: boolean; message: string }> {
+    let updateResult;
+
+    if (
+      markAsReadDto?.notificationIds &&
+      markAsReadDto.notificationIds.length > 0
+    ) {
+      // 특정 알림들만 읽음 처리
+      updateResult = await this.notificationRepository.update(
+        {
+          id: In(markAsReadDto.notificationIds),
+          recipientUuid: userUuid,
+          isRead: false,
+        },
+        { isRead: true },
+      );
+    } else {
+      // 모든 미읽음 알림을 읽음 처리
+      updateResult = await this.notificationRepository.update(
+        {
+          recipientUuid: userUuid,
+          isRead: false,
+        },
+        { isRead: true },
+      );
+    }
+
+    return {
+      success: true,
+      message: `${updateResult.affected || 0}개의 알림이 읽음 처리되었습니다.`,
+    };
+  }
+
+  /**
+   * 알림 삭제
+   */
+  async deleteNotification(
+    userUuid: string,
+    notificationId: number,
+  ): Promise<{ success: boolean; message: string }> {
+    const notification = await this.notificationRepository.findOne({
+      where: {
+        id: notificationId,
+        recipientUuid: userUuid,
+      },
+    });
+
+    if (!notification) {
+      BusinessException.notificationNotFound(notificationId);
+    }
+
+    await this.notificationRepository.remove(notification);
+
+    return {
+      success: true,
+      message: '알림이 삭제되었습니다.',
+    };
+  }
+
+  /**
+   * 사용자의 미읽음 알림 개수 조회
+   */
+  async getUnreadCount(userUuid: string): Promise<{ unreadCount: number }> {
+    const unreadCount = await this.notificationRepository.count({
+      where: {
+        recipientUuid: userUuid,
+        isRead: false,
+      },
+    });
+
+    return { unreadCount };
+  }
+
+  /**
+   * 알림 엔티티를 응답 DTO로 변환
+   */
+  private mapToResponseDto(
+    notification: Notification,
+  ): NotificationResponseDto {
+    return {
+      id: notification.id,
+      recipientUuid: notification.recipientUuid,
+      senderUuid: notification.senderUuid,
+      type: notification.type,
+      title: notification.title,
+      content: notification.content,
+      data: notification.data,
+      isRead: notification.isRead,
+      isSent: notification.isSent,
+      createdAt: notification.createdAt,
+      updatedAt: notification.updatedAt,
+    };
+  }
+
+  /**
+   * 친구 요청 알림 생성 (다른 모듈에서 호출)
+   */
+  async createFriendRequestNotification(
+    recipientUuid: string,
+    senderUuid: string,
+    senderNickname: string,
+  ): Promise<NotificationResponseDto> {
+    return this.createNotification({
+      recipientUuid,
+      senderUuid,
+      type: NotificationType.FRIEND_REQUEST,
+      title: '친구 요청이 도착했습니다',
+      content: `${senderNickname}님이 친구 요청을 보냈습니다.`,
+      data: { senderUuid, senderNickname },
+    });
+  }
+
+  /**
+   * 친구 수락 알림 생성 (다른 모듈에서 호출)
+   */
+  async createFriendAcceptedNotification(
+    recipientUuid: string,
+    senderUuid: string,
+    senderNickname: string,
+  ): Promise<NotificationResponseDto> {
+    return this.createNotification({
+      recipientUuid,
+      senderUuid,
+      type: NotificationType.FRIEND_ACCEPTED,
+      title: '친구 요청이 수락되었습니다',
+      content: `${senderNickname}님이 친구 요청을 수락했습니다.`,
+      data: { senderUuid, senderNickname },
+    });
+  }
+
+  /**
+   * 챌린지 초대 알림 생성 (다른 모듈에서 호출)
+   */
+  async createChallengeInviteNotification(
+    recipientUuid: string,
+    senderUuid: string,
+    senderNickname: string,
+    challengeTitle: string,
+    challengeUuid: string,
+  ): Promise<NotificationResponseDto> {
+    return this.createNotification({
+      recipientUuid,
+      senderUuid,
+      type: NotificationType.CHALLENGE_INVITE,
+      title: '챌린지 초대가 도착했습니다',
+      content: `${senderNickname}님이 "${challengeTitle}" 챌린지에 초대했습니다.`,
+      data: { senderUuid, senderNickname, challengeUuid, challengeTitle },
+    });
+  }
+
+  /**
+   * 게시글 좋아요 알림 생성 (다른 모듈에서 호출)
+   */
+  async createPostLikeNotification(
+    recipientUuid: string,
+    senderUuid: string,
+    senderNickname: string,
+    postUuid: string,
+  ): Promise<NotificationResponseDto> {
+    return this.createNotification({
+      recipientUuid,
+      senderUuid,
+      type: NotificationType.POST_LIKE,
+      title: '게시글에 좋아요가 달렸습니다',
+      content: `${senderNickname}님이 회원님의 게시글에 좋아요를 눌렀습니다.`,
+      data: { senderUuid, senderNickname, postUuid },
+    });
+  }
+
+  /**
+   * 게시글 댓글 알림 생성 (다른 모듈에서 호출)
+   */
+  async createPostCommentNotification(
+    recipientUuid: string,
+    senderUuid: string,
+    senderNickname: string,
+    postUuid: string,
+    commentContent: string,
+  ): Promise<NotificationResponseDto> {
+    return this.createNotification({
+      recipientUuid,
+      senderUuid,
+      type: NotificationType.POST_COMMENT,
+      title: '게시글에 댓글이 달렸습니다',
+      content: `${senderNickname}님이 회원님의 게시글에 댓글을 달았습니다: "${commentContent}"`,
+      data: { senderUuid, senderNickname, postUuid, commentContent },
+    });
+  }
+
+  /**
+   * 새 메시지 알림 생성 (다른 모듈에서 호출)
+   */
+  async createNewMessageNotification(
+    recipientUuid: string,
+    senderUuid: string,
+    senderNickname: string,
+    chatRoomUuid: string,
+    messageContent: string,
+  ): Promise<NotificationResponseDto> {
+    return this.createNotification({
+      recipientUuid,
+      senderUuid,
+      type: NotificationType.NEW_MESSAGE,
+      title: '새 메시지가 도착했습니다',
+      content: `${senderNickname}: ${messageContent}`,
+      data: { senderUuid, senderNickname, chatRoomUuid, messageContent },
+    });
+  }
+}

--- a/src/utils/custom-exception.ts
+++ b/src/utils/custom-exception.ts
@@ -236,4 +236,11 @@ export class BusinessException {
   static expiredToken(): never {
     CustomException.throw(ErrorCode.EXPIRED_TOKEN);
   }
+
+  // === 알림 관련 ===
+  static notificationNotFound(notificationId?: number): never {
+    CustomException.throw(ErrorCode.NOTIFICATION_NOT_FOUND, undefined, {
+      notificationId,
+    });
+  }
 }


### PR DESCRIPTION
## 🔗 이슈 번호
#9 
## ✅ 작업 내용
1. 엔티티 및 타입 정의
- Notification 엔티티 구현 (src/entities/notification.entity.ts)
- NotificationType enum 정의 (친구요청, 챌린지 초대, 게시글 알림 등)
2. API 엔드포인트 구현
- POST /notifications - 알림 생성 (시스템용)
- GET /notifications - 사용자 알림 목록 조회 (페이지네이션, 필터링 지원)
- GET /notifications/unread-count - 읽지 않은 알림 개수 조회
- PATCH /notifications/mark-as-read - 특정 알림 읽음 처리
- PATCH /notifications/mark-all-as-read - 모든 알림 읽음 처리
- DELETE /notifications/:id - 알림 삭제
3. DTO 및 검증
- CreateNotificationDto - 알림 생성 요청
- GetNotificationsDto - 알림 목록 조회
- MarkAsReadDto - 읽음 상태 변경
- NotificationResponseDto - 알림 응답 데이터
- NotificationListResponseDto - 알림 목록 응답
## 🗣️ 공유 사항
