### PR TITLE
[FEAT] 챌린지 채팅방 동기화

### DIFF
--- a/src/modules/bo/bo.controller.ts
+++ b/src/modules/bo/bo.controller.ts
@@ -5,9 +5,26 @@ import {
   Param,
   DefaultValuePipe,
   ParseIntPipe,
+  Put,
+  Delete,
+  Body,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiQuery, ApiParam } from '@nestjs/swagger';
 import { BoService } from './bo.service';
+import { UpdateUserDto } from './dto/update-user.dto';
+import { UpdatePostDto } from './dto/update-post.dto';
+import { UpdateCommentDto } from './dto/update-comment.dto';
+import { UpdateChallengeDto } from './dto/update-challenge.dto';
+import {
+  ApiUpdateUser,
+  ApiDeleteUser,
+  ApiUpdatePost,
+  ApiDeletePost,
+  ApiUpdateComment,
+  ApiDeleteComment,
+  ApiUpdateChallenge,
+  ApiDeleteChallenge,
+} from './decorators/bo.swagger';
 
 @ApiTags('BO (Back Office)')
 @Controller('bo')
@@ -210,5 +227,69 @@ export class BoController {
     @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
   ) {
     return this.boService.getFriendships(page, limit);
+  }
+
+  // === 사용자 수정/삭제 ===
+  @Put('users/:userUuid')
+  @ApiUpdateUser()
+  async updateUser(
+    @Param('userUuid') userUuid: string,
+    @Body() updateUserDto: UpdateUserDto,
+  ) {
+    return this.boService.updateUser(userUuid, updateUserDto);
+  }
+
+  @Delete('users/:userUuid')
+  @ApiDeleteUser()
+  async deleteUser(@Param('userUuid') userUuid: string) {
+    return this.boService.deleteUser(userUuid);
+  }
+
+  // === 게시글 수정/삭제 ===
+  @Put('posts/:postUuid')
+  @ApiUpdatePost()
+  async updatePost(
+    @Param('postUuid') postUuid: string,
+    @Body() updatePostDto: UpdatePostDto,
+  ) {
+    return this.boService.updatePost(postUuid, updatePostDto);
+  }
+
+  @Delete('posts/:postUuid')
+  @ApiDeletePost()
+  async deletePost(@Param('postUuid') postUuid: string) {
+    return this.boService.deletePost(postUuid);
+  }
+
+  // === 댓글 수정/삭제 ===
+  @Put('comments/:commentId')
+  @ApiUpdateComment()
+  async updateComment(
+    @Param('commentId', ParseIntPipe) commentId: number,
+    @Body() updateCommentDto: UpdateCommentDto,
+  ) {
+    return this.boService.updateComment(commentId, updateCommentDto);
+  }
+
+  @Delete('comments/:commentId')
+  @ApiDeleteComment()
+  async deleteComment(@Param('commentId', ParseIntPipe) commentId: number) {
+    return this.boService.deleteComment(commentId);
+  }
+
+  // === 챌린지 수정/삭제 ===
+  @Put('challenges/:challengeUuid')
+  @ApiUpdateChallenge()
+  async updateChallenge(
+    @Param('challengeUuid') challengeUuid: string,
+    @Body() updateChallengeDto: UpdateChallengeDto,
+  ) {
+    return this.boService.updateChallenge(challengeUuid, updateChallengeDto);
+  }
+
+  @Delete('challenges/:challengeUuid')
+  @ApiDeleteChallenge()
+  async deleteChallenge(@Param('challengeUuid') challengeUuid: string) {
+    return this.boService.deleteChallenge(challengeUuid);
   }
 }

--- a/src/modules/bo/bo.service.ts
+++ b/src/modules/bo/bo.service.ts
@@ -322,4 +322,164 @@ export class BoService {
       totalPages: Math.ceil(total / limit),
     };
   }
+
+  // === 사용자 수정/삭제 ===
+  async updateUser(userUuid: string, updateData: any) {
+    const user = await this.userRepository.findOne({
+      where: { userUuid },
+    });
+
+    if (!user) {
+      throw new Error('사용자를 찾을 수 없습니다.');
+    }
+
+    Object.assign(user, updateData);
+    user.updatedAt = new Date();
+
+    const updatedUser = await this.userRepository.save(user);
+
+    return {
+      success: true,
+      message: '사용자 정보가 수정되었습니다.',
+      user: updatedUser,
+    };
+  }
+
+  async deleteUser(userUuid: string) {
+    const user = await this.userRepository.findOne({
+      where: { userUuid },
+    });
+
+    if (!user) {
+      throw new Error('사용자를 찾을 수 없습니다.');
+    }
+
+    await this.userRepository.remove(user);
+
+    return {
+      success: true,
+      message: '사용자가 삭제되었습니다.',
+      deletedId: userUuid,
+    };
+  }
+
+  // === 게시글 수정/삭제 ===
+  async updatePost(postUuid: string, updateData: any) {
+    const post = await this.postRepository.findOne({
+      where: { postUuid },
+    });
+
+    if (!post) {
+      throw new Error('게시글을 찾을 수 없습니다.');
+    }
+
+    Object.assign(post, updateData);
+    post.updatedAt = new Date();
+
+    const updatedPost = await this.postRepository.save(post);
+
+    return {
+      success: true,
+      message: '게시글이 수정되었습니다.',
+      post: updatedPost,
+    };
+  }
+
+  async deletePost(postUuid: string) {
+    const post = await this.postRepository.findOne({
+      where: { postUuid },
+    });
+
+    if (!post) {
+      throw new Error('게시글을 찾을 수 없습니다.');
+    }
+
+    await this.postRepository.remove(post);
+
+    return {
+      success: true,
+      message: '게시글이 삭제되었습니다.',
+      deletedId: postUuid,
+    };
+  }
+
+  // === 댓글 수정/삭제 ===
+  async updateComment(commentId: number, updateData: any) {
+    const comment = await this.commentRepository.findOne({
+      where: { id: commentId },
+    });
+
+    if (!comment) {
+      throw new Error('댓글을 찾을 수 없습니다.');
+    }
+
+    Object.assign(comment, updateData);
+    comment.updatedAt = new Date();
+
+    const updatedComment = await this.commentRepository.save(comment);
+
+    return {
+      success: true,
+      message: '댓글이 수정되었습니다.',
+      comment: updatedComment,
+    };
+  }
+
+  async deleteComment(commentId: number) {
+    const comment = await this.commentRepository.findOne({
+      where: { id: commentId },
+    });
+
+    if (!comment) {
+      throw new Error('댓글을 찾을 수 없습니다.');
+    }
+
+    await this.commentRepository.remove(comment);
+
+    return {
+      success: true,
+      message: '댓글이 삭제되었습니다.',
+      deletedId: commentId.toString(),
+    };
+  }
+
+  // === 챌린지 수정/삭제 ===
+  async updateChallenge(challengeUuid: string, updateData: any) {
+    const challenge = await this.challengeRepository.findOne({
+      where: { challengeUuid },
+    });
+
+    if (!challenge) {
+      throw new Error('챌린지를 찾을 수 없습니다.');
+    }
+
+    Object.assign(challenge, updateData);
+    challenge.updatedAt = new Date();
+
+    const updatedChallenge = await this.challengeRepository.save(challenge);
+
+    return {
+      success: true,
+      message: '챌린지가 수정되었습니다.',
+      challenge: updatedChallenge,
+    };
+  }
+
+  async deleteChallenge(challengeUuid: string) {
+    const challenge = await this.challengeRepository.findOne({
+      where: { challengeUuid },
+    });
+
+    if (!challenge) {
+      throw new Error('챌린지를 찾을 수 없습니다.');
+    }
+
+    await this.challengeRepository.remove(challenge);
+
+    return {
+      success: true,
+      message: '챌린지가 삭제되었습니다.',
+      deletedId: challengeUuid,
+    };
+  }
 }

--- a/src/modules/bo/decorators/bo.swagger.ts
+++ b/src/modules/bo/decorators/bo.swagger.ts
@@ -1,0 +1,247 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiParam, ApiBody } from '@nestjs/swagger';
+import { UpdateUserDto } from '../dto/update-user.dto';
+import { UpdatePostDto } from '../dto/update-post.dto';
+import { UpdateCommentDto } from '../dto/update-comment.dto';
+import { UpdateChallengeDto } from '../dto/update-challenge.dto';
+import { DeleteResponseDto } from '../dto/delete-response.dto';
+
+// 사용자 수정 데코레이터
+export const ApiUpdateUser = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '사용자 정보 수정',
+      description: '관리자가 사용자 정보를 수정합니다.',
+    }),
+    ApiParam({
+      name: 'userUuid',
+      description: '사용자 UUID',
+      example: '123e4567-e89b-12d3-a456-426614174000',
+    }),
+    ApiBody({
+      type: UpdateUserDto,
+      description: '수정할 사용자 정보',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '사용자 정보가 성공적으로 수정되었습니다.',
+      schema: {
+        type: 'object',
+        properties: {
+          success: { type: 'boolean', example: true },
+          message: { type: 'string', example: '사용자 정보가 수정되었습니다.' },
+          user: {
+            type: 'object',
+            description: '수정된 사용자 정보',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: '사용자를 찾을 수 없습니다.',
+    }),
+  );
+
+// 사용자 삭제 데코레이터
+export const ApiDeleteUser = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '사용자 삭제',
+      description: '관리자가 사용자를 삭제합니다.',
+    }),
+    ApiParam({
+      name: 'userUuid',
+      description: '사용자 UUID',
+      example: '123e4567-e89b-12d3-a456-426614174000',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '사용자가 성공적으로 삭제되었습니다.',
+      type: DeleteResponseDto,
+    }),
+    ApiResponse({
+      status: 404,
+      description: '사용자를 찾을 수 없습니다.',
+    }),
+  );
+
+// 게시글 수정 데코레이터
+export const ApiUpdatePost = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '게시글 수정',
+      description: '관리자가 게시글을 수정합니다.',
+    }),
+    ApiParam({
+      name: 'postUuid',
+      description: '게시글 UUID',
+      example: '123e4567-e89b-12d3-a456-426614174000',
+    }),
+    ApiBody({
+      type: UpdatePostDto,
+      description: '수정할 게시글 정보',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '게시글이 성공적으로 수정되었습니다.',
+      schema: {
+        type: 'object',
+        properties: {
+          success: { type: 'boolean', example: true },
+          message: { type: 'string', example: '게시글이 수정되었습니다.' },
+          post: {
+            type: 'object',
+            description: '수정된 게시글 정보',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: '게시글을 찾을 수 없습니다.',
+    }),
+  );
+
+// 게시글 삭제 데코레이터
+export const ApiDeletePost = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '게시글 삭제',
+      description: '관리자가 게시글을 삭제합니다.',
+    }),
+    ApiParam({
+      name: 'postUuid',
+      description: '게시글 UUID',
+      example: '123e4567-e89b-12d3-a456-426614174000',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '게시글이 성공적으로 삭제되었습니다.',
+      type: DeleteResponseDto,
+    }),
+    ApiResponse({
+      status: 404,
+      description: '게시글을 찾을 수 없습니다.',
+    }),
+  );
+
+// 댓글 수정 데코레이터
+export const ApiUpdateComment = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '댓글 수정',
+      description: '관리자가 댓글을 수정합니다.',
+    }),
+    ApiParam({
+      name: 'commentId',
+      description: '댓글 ID',
+      example: '1',
+    }),
+    ApiBody({
+      type: UpdateCommentDto,
+      description: '수정할 댓글 정보',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '댓글이 성공적으로 수정되었습니다.',
+      schema: {
+        type: 'object',
+        properties: {
+          success: { type: 'boolean', example: true },
+          message: { type: 'string', example: '댓글이 수정되었습니다.' },
+          comment: {
+            type: 'object',
+            description: '수정된 댓글 정보',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: '댓글을 찾을 수 없습니다.',
+    }),
+  );
+
+// 댓글 삭제 데코레이터
+export const ApiDeleteComment = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '댓글 삭제',
+      description: '관리자가 댓글을 삭제합니다.',
+    }),
+    ApiParam({
+      name: 'commentId',
+      description: '댓글 ID',
+      example: '1',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '댓글이 성공적으로 삭제되었습니다.',
+      type: DeleteResponseDto,
+    }),
+    ApiResponse({
+      status: 404,
+      description: '댓글을 찾을 수 없습니다.',
+    }),
+  );
+
+// 챌린지 수정 데코레이터
+export const ApiUpdateChallenge = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '챌린지 수정',
+      description: '관리자가 챌린지를 수정합니다.',
+    }),
+    ApiParam({
+      name: 'challengeUuid',
+      description: '챌린지 UUID',
+      example: '123e4567-e89b-12d3-a456-426614174000',
+    }),
+    ApiBody({
+      type: UpdateChallengeDto,
+      description: '수정할 챌린지 정보',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '챌린지가 성공적으로 수정되었습니다.',
+      schema: {
+        type: 'object',
+        properties: {
+          success: { type: 'boolean', example: true },
+          message: { type: 'string', example: '챌린지가 수정되었습니다.' },
+          challenge: {
+            type: 'object',
+            description: '수정된 챌린지 정보',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: '챌린지를 찾을 수 없습니다.',
+    }),
+  );
+
+// 챌린지 삭제 데코레이터
+export const ApiDeleteChallenge = () =>
+  applyDecorators(
+    ApiOperation({
+      summary: '챌린지 삭제',
+      description: '관리자가 챌린지를 삭제합니다.',
+    }),
+    ApiParam({
+      name: 'challengeUuid',
+      description: '챌린지 UUID',
+      example: '123e4567-e89b-12d3-a456-426614174000',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '챌린지가 성공적으로 삭제되었습니다.',
+      type: DeleteResponseDto,
+    }),
+    ApiResponse({
+      status: 404,
+      description: '챌린지를 찾을 수 없습니다.',
+    }),
+  );

--- a/src/modules/bo/dto/delete-response.dto.ts
+++ b/src/modules/bo/dto/delete-response.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeleteResponseDto {
+  @ApiProperty({
+    description: '삭제 성공 여부',
+    example: true,
+  })
+  success: boolean;
+
+  @ApiProperty({
+    description: '삭제 응답 메시지',
+    example: '성공적으로 삭제되었습니다.',
+  })
+  message: string;
+
+  @ApiProperty({
+    description: '삭제된 아이템 UUID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  deletedId: string;
+}

--- a/src/modules/bo/dto/update-challenge.dto.ts
+++ b/src/modules/bo/dto/update-challenge.dto.ts
@@ -1,0 +1,57 @@
+import {
+  IsOptional,
+  IsString,
+  IsEnum,
+  IsNumber,
+  IsBoolean,
+} from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { ChallengeStatusType } from '../../../types/challenge.enum';
+
+export class UpdateChallengeDto {
+  @ApiProperty({
+    description: '챌린지 제목',
+    example: '수정된 챌린지 제목',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @ApiProperty({
+    description: '챌린지 소개',
+    example: '수정된 챌린지 소개',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  introduce?: string;
+
+  @ApiProperty({
+    description: '목표 달성 일수',
+    example: 30,
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  goalDays?: number;
+
+  @ApiProperty({
+    description: '챌린지 상태',
+    enum: ChallengeStatusType,
+    example: ChallengeStatusType.IN_PROGRESS,
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(ChallengeStatusType)
+  status?: ChallengeStatusType;
+
+  @ApiProperty({
+    description: '삭제 여부',
+    example: false,
+    required: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  isDeleted?: boolean;
+}

--- a/src/modules/bo/dto/update-comment.dto.ts
+++ b/src/modules/bo/dto/update-comment.dto.ts
@@ -1,0 +1,22 @@
+import { IsOptional, IsString, IsBoolean } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateCommentDto {
+  @ApiProperty({
+    description: '댓글 내용',
+    example: '수정된 댓글 내용',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  content?: string;
+
+  @ApiProperty({
+    description: '삭제 여부',
+    example: false,
+    required: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  isDeleted?: boolean;
+}

--- a/src/modules/bo/dto/update-post.dto.ts
+++ b/src/modules/bo/dto/update-post.dto.ts
@@ -1,0 +1,44 @@
+import { IsOptional, IsString, IsArray, IsBoolean } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdatePostDto {
+  @ApiProperty({
+    description: '게시글 제목',
+    example: '수정된 제목',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @ApiProperty({
+    description: '게시글 내용',
+    example: '수정된 내용입니다.',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  content?: string;
+
+  @ApiProperty({
+    description: '이미지 URL 배열',
+    example: [
+      'https://example.com/image1.jpg',
+      'https://example.com/image2.jpg',
+    ],
+    required: false,
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  images?: string[];
+
+  @ApiProperty({
+    description: '삭제 여부',
+    example: false,
+    required: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  isDeleted?: boolean;
+}

--- a/src/modules/bo/dto/update-user.dto.ts
+++ b/src/modules/bo/dto/update-user.dto.ts
@@ -1,0 +1,42 @@
+import { IsOptional, IsString, IsEnum, IsBoolean } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { UserStatusType } from '../../../types/user-status.enum';
+
+export class UpdateUserDto {
+  @ApiProperty({
+    description: '사용자 닉네임',
+    example: '수정된닉네임',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  nickname?: string;
+
+  @ApiProperty({
+    description: '사용자 소개',
+    example: '수정된 소개입니다.',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  introduce?: string;
+
+  @ApiProperty({
+    description: '사용자 상태',
+    enum: UserStatusType,
+    example: UserStatusType.ACTIVE,
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(UserStatusType)
+  status?: UserStatusType;
+
+  @ApiProperty({
+    description: '탈퇴 여부',
+    example: false,
+    required: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  isDeleted?: boolean;
+}

--- a/src/modules/challenges/challenge.module.ts
+++ b/src/modules/challenges/challenge.module.ts
@@ -6,6 +6,7 @@ import { Post } from '@/entities/post.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersModule } from '../users/users.module';
 import { PostsModule } from '../posts/posts.module';
+import { ChatModule } from '../chat/chat.module';
 import { forwardRef } from '@nestjs/common';
 import { ChallengeService } from './challenge.service';
 
@@ -14,6 +15,7 @@ import { ChallengeService } from './challenge.service';
     TypeOrmModule.forFeature([Challenge, User, Post]),
     forwardRef(() => UsersModule),
     forwardRef(() => PostsModule),
+    forwardRef(() => ChatModule),
   ],
   controllers: [ChallengeController],
   providers: [ChallengeService],


### PR DESCRIPTION
## 🔗 이슈 번호
#40 
## ✅ 작업 내용
1. ChallengeModule 수정
  - ChatModule을 임포트하여 ChatService를 사용할 수 있도록 설정
2. ChallengeService 수정
  - ChatService를 의존성 주입으로 추가
  - 챌린지 생성/참여/나가기 시 채팅방 동기화 로직 추가
3. ChatService 확장
  - addParticipantToChallengeRoom(): 챌린지 채팅방에 참여자 추가
  - removeParticipantFromChallengeRoom(): 챌린지 채팅방에서 참여자 제거
4. BO쪽 기능 추가
  - PUT, DELETE 메서드 추가

## 🗣️ 공유 사항
